### PR TITLE
Fix language filtering in progress bar

### DIFF
--- a/www/views.py
+++ b/www/views.py
@@ -62,7 +62,7 @@ def event (request, event_acronym, *args, **kwargs):
         if "lang" in kwargs:
             lang = kwargs.pop("lang")
             my_talks = my_talks.filter(orig_language__lang_amara_short = lang)
-            subtitles_filters["language"] = lang
+            subtitles_filters["language__lang_amara_short"] = lang
 
         time_sum = 0
         transcribed = 0

--- a/www/views.py
+++ b/www/views.py
@@ -63,6 +63,7 @@ def event (request, event_acronym, *args, **kwargs):
             lang = kwargs.pop("lang")
             my_talks = my_talks.filter(orig_language__lang_amara_short = lang)
             subtitles_filters["language__lang_amara_short"] = lang
+            subtitles_filters["is_original_lang"] = True
 
         time_sum = 0
         transcribed = 0


### PR DESCRIPTION
Only account for original-language subtitles of the specified language in the progress bar.