### PR TITLE
Make deciding which state a subtitle is in robust

### DIFF
--- a/update_subtitles_via_amara_import.py
+++ b/update_subtitles_via_amara_import.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/python3
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 #==============================================================================
@@ -44,14 +44,14 @@ def reset_subtitle(my_subtitle):
         my_subtitle.time_processed_syncing = "00:00:00"
         my_subtitle.time_processed_quality_check_done = "00:00:00"
         my_subtitle.state_id = 2 # Transcribed until
-    # If the subtitle is a translation..   
+    # If the subtitle is a translation..
     elif not my_subtitle.is_original_lang:
         my_subtitle.state_id = 11 # Translated until...
         my_subtitle.time_processed_translating = "00:00:00"
-     
+
     my_subtitle.save()
 
-    
+
 # Set all states to complete and sync and tweet-flags, no matter if translation or original
 def set_subtitle_complete(my_subtitle):
     # Stuff which need to be done anyway..
@@ -67,12 +67,12 @@ def set_subtitle_complete(my_subtitle):
         my_subtitle.time_processed_syncing = my_subtitle.talk.video_duration
         my_subtitle.time_processed_quality_check_done = my_subtitle.talk.video_duration
         my_subtitle.state_id = 8 # Complete
-    
+
     # Stuff only if the subtitle is a translation
     elif not my_subtitle.is_orignal_lang:
         my_subtitle.time_processed_translating = my_subtitle.talk.video_duration
         my_subtitle.state_id = 12 # Translation finished
-    
+
     my_subtitle.save()
 
 
@@ -93,16 +93,16 @@ for any_talk in all_talks_with_amara_key:
     # Create URL depending on amara_key
     url = basis_url+any_talk.amara_key+"/languages/?format=json"
     print(url)
-    
+
     # Get json file form amara and convert to dict
     request = urllib.request.Request(url, headers = anti_bot_header)
     response = urllib.request.urlopen(request)
     encoding = response.info().get_param('charset', 'utf8')
     amara_answer = json.loads(response.read().decode(encoding))
-    
+
     # Number of available subtitle languages, read from json output
     number_of_available_subtitles = amara_answer["meta"]["total_count"]
-        
+
     # Get necessary info from json file for one subtitle
     subtitles_counter = 0
     while subtitles_counter < number_of_available_subtitles:
@@ -116,10 +116,10 @@ for any_talk in all_talks_with_amara_key:
             amara_subtitles_complete = amara_answer["objects"][subtitles_counter]["subtitles_complete"]
 
             language = Language.objects.get(lang_amara_short = amara_language_code)
-            
+
             # Get or create subtitle entry from database
             subtitle = Subtitle.objects.get_or_create(language = language , talk = any_talk)[0]
-            
+
             # Almost only change something in the database if the version of the subtitle is not the same as before
             if (subtitle.revision != amara_num_versions):
                 subtitle.is_original_lang = amara_is_original
@@ -127,7 +127,7 @@ for any_talk in all_talks_with_amara_key:
                 subtitle.complete = amara_subtitles_complete
                 subtitle.last_changed_on_amara = datetime.now(timezone.utc)
                 subtitle.save()
-                
+
                 # If subtitle is orignal and new inserted into the database, set state to transcribed until..
                 if (subtitle.revision == "1" and subtitle.is_original_lang):
                     subtitle.state_id = 2
@@ -139,7 +139,7 @@ for any_talk in all_talks_with_amara_key:
                 # If orignal or translation and finished set state to finished
                 if subtitle.complete:
                     set_subtitle_complete(subtitle)
-                # If translation and not finished set state to translation in progress    
+                # If translation and not finished set state to translation in progress
                 elif (not subtitle.is_original_lang and not subtitle.complete):
                     # If the state was set to finished but isn't anymore, remove from ftp
                     # Server and reset the timestamp
@@ -151,13 +151,13 @@ for any_talk in all_talks_with_amara_key:
                     # Also reset the timestamps
                     if subtitle.state_id == 8:
                         reset_subtitle(subtitle)
-                        
+
             # If the revision is the same, still check the complete-Flag!
             if (subtitle.revision == amara_num_versions):
                 # If the saved subtitle on amara is not complete anymore but was complete
                 if not amara_subtitles_complete and subtitle.complete:
                     reset_subtitle(subtitle)
-                    
+
         subtitles_counter += 1
 
 print("Import Done!")
@@ -168,7 +168,7 @@ my_subtitles = Subtitle.objects.all().order_by("-id").select_related("States").s
 for my_subtitle in my_subtitles:
     # Original language
     if my_subtitle.is_original_lang:
-        # Workaround for manual setting of the time transcribed to exact the video length - doesn't work!  
+        # Workaround for manual setting of the time transcribed to exact the video length - doesn't work!
         if (my_subtitle.time_processed_transcribing == my_subtitle.talk.video_duration) \
             and (my_subtitle.time_processed_syncing == "00:00:00") \
             and (my_subtitle.time_quality_check_done == "00:00:00" ) \
@@ -180,19 +180,17 @@ for my_subtitle in my_subtitles:
             my_subtitle.save()
             print("WTF")
         # Still in transcribing process
-        if my_subtitle.time_processed_transcribing < my_subtitle.talk.video_duration:
+        if my_subtitle.transcription_in_progress:
             if my_subtitle.state_id != 2:
                 my_subtitle.state_id = 2 # Transcribed until...
                 my_subtitle.save()
         # Still in syncing procress
-        elif my_subtitle.time_processed_syncing < my_subtitle.talk.video_duration \
-            and my_subtitle.state_id != 2:
+        elif my_subtitle.syncing_in_progress:
             if my_subtitle.state_id != 5:
                 my_subtitle.state_id = 5 # Synced until...
                 my_subtitle.save()
         # Still in quality check procress
-        elif my_subtitle.time_quality_check_done < my_subtitle.talk.video_duration \
-            and my_subtitle.state_id != 2:
+        elif my_subtitle.quality_check_in_progress:
             if my_subtitle.state_id != 7:
                 my_subtitle.state_id = 7 # Quality check done until...
                 my_subtitle.save()
@@ -201,13 +199,13 @@ for my_subtitle in my_subtitles:
             if my_subtitle.state_id != 8:
                 my_subtitle.state_id = 8 # Completed!
                 my_subtitle.save()
-        
-            
-        
+
+
+
     # Translation
     else:
         # Still in translating process
-        if my_subtitle.time_processed_translating < my_subtitle.talk.video_duration:
+        if my_subtitle.translation_in_progress:
             if my_subtitle.state_id != 11:
                 my_subtitle.state_id = 11 # Translated until...
                 my_subtitle.save()
@@ -225,5 +223,5 @@ for my_subtitle in my_subtitles:
                  my_subtitle.needs_removal_from_ftp = True
                  my_subtitle.needs_removal_from_YT = True
                  my_subtitle.save()
-    
+
 print(".. done!")

--- a/www/models.py
+++ b/www/models.py
@@ -175,10 +175,28 @@ class Subtitle(BasisModell):
     #comment = models.TextField(default = "")
     last_changed_on_amara = models.DateTimeField(default = datetime.min, blank = True)
 
+    def _still_in_progress(self, timestamp, state, original_language=True):
+        if original_language != self.is_original_lang:
+            return False
+
+        return ((timestamp < self.talk.video_duration) or
+                (self.state_id == state and timestamp <= self.talk.video_duration))
+
     @property
     def transcription_in_progress(self):
-        return self.is_original_lang and (self.time_processed_transcribing <
-                                          self.talk.video_duration)
+        return self._still_in_progress(self.time_processed_transcribing, state=2)
+
+    @property
+    def syncing_in_progress(self):
+        return self._still_in_progress(self.time_processed_syncing, state=5)
+
+    @property
+    def quality_check_in_progress(self):
+        return self._still_in_progress(self.time_quality_check_done, state=7)
+
+    @property
+    def translation_in_progress(self):
+        return self._still_in_progress(self.time_processed_translating, state=11, original_language=False)
 
 # Links from the Fahrplan
 class Links(BasisModell):

--- a/www/views.py
+++ b/www/views.py
@@ -165,41 +165,33 @@ Für den Fall ohne Quality check wäre es:
     if sub.complete:
         return "Finished :)"
 
-    if sub.is_original_lang:
-        if sub.state_id == 2:      # still transcribing
-            # remove the unnecessary fields
-            #form.fields.pop("time_processed_transcribing")
-            form.fields.pop("time_processed_syncing")
-            form.fields.pop("time_quality_check_done")
-            form.fields.pop("time_processed_translating")
-
-            # add finish transcribing button
-            form.quick_btn = 'Finish Transcribing'
-
-            return form
-        elif sub.state_id == 7:    # in quality control
-            # remove the unnecessary fields
-            form.fields.pop("time_processed_transcribing")
-            form.fields.pop("time_processed_syncing")
-            #form.fields.pop("time_quality_check_done")
-            form.fields.pop("time_processed_translating")
-
-            # add finish transcribing button
-            form.quick_btn = 'Finish quality check'
-
-            return form
-    else: #no sub.is_original_lang
-        if sub.state_id == 11:     # in translation
-            # remove the unnecessary fields
-            form.fields.pop("time_processed_transcribing")
-            form.fields.pop("time_processed_syncing")
-            form.fields.pop("time_quality_check_done")
-            #form.fields.pop("time_processed_translating")
-
-            # add finish transcribing button
-            form.quick_btn = 'Finish Translating'
-
-            return form
+    if sub.transcription_in_progress:
+        # remove the unnecessary fields
+        #form.fields.pop("time_processed_transcribing")
+        form.fields.pop("time_processed_syncing")
+        form.fields.pop("time_quality_check_done")
+        form.fields.pop("time_processed_translating")
+     # add finish transcribing button
+        form.quick_btn = 'Finish Transcribing'
+        return form
+    elif sub.quality_check_in_progress:
+        # remove the unnecessary fields
+        form.fields.pop("time_processed_transcribing")
+        form.fields.pop("time_processed_syncing")
+        #form.fields.pop("time_quality_check_done")
+        form.fields.pop("time_processed_translating")
+     # add finish transcribing button
+        form.quick_btn = 'Finish quality check'
+        return form
+    elif sub.translation_in_progress:
+        # remove the unnecessary fields
+        form.fields.pop("time_processed_transcribing")
+        form.fields.pop("time_processed_syncing")
+        form.fields.pop("time_quality_check_done")
+        #form.fields.pop("time_processed_translating")
+     # add finish transcribing button
+        form.quick_btn = 'Finish Translating'
+        return form
 
     return
 
@@ -253,23 +245,22 @@ def updateSubtitle(request, subtitle_id):
     if 'quick_finish_btn' in request.POST:
         talk = my_obj.talk
         #finish current step
-        if my_obj.is_original_lang:
-            if my_obj.state_id == 2:
-                # transcribing done
-                my_obj.time_processed_transcribing = talk.video_duration
-                my_obj.state_id = 4 # Do not touch
-                my_obj.needs_automatic_syncing = True
-                my_obj.blocked = True
-            elif my_obj.state_id == 5:
-                # Syncing is done - if manually
-                my_obj.time_processed_syncing = talk.video_duration
-                my_obj.state_id = 7 # Quality check done until
-            elif my_obj.state_id == 7:
-                # quality_check done
-                my_obj.time_quality_check_done = talk.video_duration
-                my_obj.state_id = 8 # Done
-                # Execute Python Skript for Amara Sync in the Background?!
-        elif my_obj.state_id == 11:  # Translation
+        if my_obj.transcription_in_progress:
+            # transcribing done
+            my_obj.time_processed_transcribing = talk.video_duration
+            my_obj.state_id = 4 # Do not touch
+            my_obj.needs_automatic_syncing = True
+            my_obj.blocked = True
+        elif my_obj.syncing_in_progress:
+            # Syncing is done - if manually
+            my_obj.time_processed_syncing = talk.video_duration
+            my_obj.state_id = 7 # Quality check done until
+        elif my_obj.quality_check_in_progress:
+            # quality_check done
+            my_obj.time_quality_check_done = talk.video_duration
+            my_obj.state_id = 8 # Done
+            # Execute Python Skript for Amara Sync in the Background?!
+        elif my_obj.translation_in_progress:  # Translation
             my_obj.time_processed_translating = talk.video_duration
             my_obj.state_id = 12 # Translation finished
             # Execute Python Skript for Amara Sync in the Background?!


### PR DESCRIPTION
Unify the checks which state a subtitle is in in the model instead of
spreading it throughout the views and the update scripts. Don't just
compare timestamps, but check whether the state is set correctly if the
timestamps match.