### PR TITLE
Unify progress bars, show translation progress

### DIFF
--- a/www/templates/www/event.html
+++ b/www/templates/www/event.html
@@ -18,6 +18,10 @@
         {% endfor %}
     </div>
 
+    <style>
+      td div.progress { margin-bottom: 0px; }
+    </style>
+
 	{% for talks_line in talks_chunk %}
 		<div class="row">
 			{% for every_talk in talks_line %}

--- a/www/templates/www/progress_bar_translation.html
+++ b/www/templates/www/progress_bar_translation.html
@@ -1,12 +1,12 @@
 {% comment %}
 	Progress Bar for Translations
-{% endcomment %}   
-  
-  <div class="progress"> 
+{% endcomment %}
+
+  <div class="progress" {% if value.small %} style="height: 10px;" {% endif %}>
 		<div class="progress-bar progress-bar-success" style="width: {{ value.bar_checked }}%">
-			<span class="sr-only">{{ value.bar_checked }}% Checking done</span>{{ value.bar_checked }}%
+			<span class="sr-only">{{ value.bar_checked }}% Checking done</span>{% if not value.small %}{{ value.bar_checked }}%{% endif %}
 		</div>
 		<div class="progress-bar progress-bar-grey progress-bar-striped" style="width: {{ value.bar_nothing }}%">
-            <span class="sr-only">{{ value.bar_nothing }}% Nothing done yet</span>{{ value.bar_nothing }}%
-		</div>	
-	</div> 
+            <span class="sr-only">{{ value.bar_nothing }}% Nothing done yet</span>{% if not value.small %}{{ value.bar_nothing }}%{% endif %}
+		</div>
+	</div>

--- a/www/templates/www/talk.html
+++ b/www/templates/www/talk.html
@@ -1,5 +1,6 @@
 ﻿{% extends "base.html" %}
 {% load bootstrap %}
+{% load subtitle_progress %}
 
 {% block title %}C3Subtitles{% endblock %}
 
@@ -113,11 +114,7 @@
 						</a>
 					</div>
 					<div class="col-md-5">
-						{% if sub.is_original_lang %}
-							{% include "www/progress_bar_original.html" with value=sub %}
-						{% else %}
-							{% include "www/progress_bar_translation.html" with value=sub %}       
-						{% endif %}
+                      {{ sub|progress_bar }}
 					</div>
 				</div>
 			</div>

--- a/www/templates/www/talk_small.html
+++ b/www/templates/www/talk_small.html
@@ -1,4 +1,5 @@
-﻿<a href="/talk/{{talk.pk}}" class="thumbnail">
+﻿{% load subtitle_progress %}
+<a href="/talk/{{talk.pk}}" class="thumbnail">
 	<h3>{{talk.title}}</h3>
 	<dl class="dl-horizontal">
 		<dt>Talk-ID</dt>
@@ -12,8 +13,15 @@
 		<dd>{{speaker.name}}</dd>
 		{% endfor %}
 	</dl>
-	{% if talk.has_bar %}
-	    {% include "www/progress_bar_original.html" with value=talk %}
+	{% if talk.subtitles.count > 0 %}
+        <table style="width: 100%;">
+            {% for subtitle in talk.subtitles %}
+                <tr>
+                    <th style="padding-bottom: 20px;">{{ subtitle.language.lang_amara_short }}:</th>
+                    <td>{{ subtitle|progress_bar:True }}</td>
+                </tr>
+            {% endfor %}
+        </table>
         {% if not talk.complete and talk.last_changed_on_amara %}
             <p>Last revision: {{ talk.last_changed_on_amara|timesince }} ago</p>
         {% endif %}

--- a/www/templates/www/talk_small.html
+++ b/www/templates/www/talk_small.html
@@ -17,14 +17,19 @@
         <table style="width: 100%;">
             {% for subtitle in talk.subtitles %}
                 <tr>
-                    <th style="padding-bottom: 20px;">{{ subtitle.language.lang_amara_short }}:</th>
+                    <th>{{ subtitle.language.lang_amara_short }}:</th>
                     <td>{{ subtitle|progress_bar:True }}</td>
                 </tr>
+                {% if not subtitle.complete and subtitle.revision > 0 %}
+                    {% if subtitle.last_changed_on_amara >= subtitle.created %}
+                        <tr>
+                            <th></th>
+                            <td>Last revision: {{ subtitle.last_changed_on_amara|timesince }} ago</td>
+                        </tr>
+                    {% endif %}
+                {% endif %}
             {% endfor %}
         </table>
-        {% if not talk.complete and talk.last_changed_on_amara %}
-            <p>Last revision: {{ talk.last_changed_on_amara|timesince }} ago</p>
-        {% endif %}
 	{% else %}
 		<p>No subtitles yet in the language of the presentation.<br />Start working on them!</p>
     {% endif %}

--- a/www/templatetags/subtitle_progress.py
+++ b/www/templatetags/subtitle_progress.py
@@ -1,0 +1,24 @@
+from django import template
+from django.template.loader import render_to_string
+from django.utils.safestring import mark_safe
+
+from ..views import _progress_bar, seconds
+
+register = template.Library()
+
+@register.filter(needs_autoescape=True)
+def progress_bar(subtitle, small_translations=False, autoescape=None):
+    if subtitle.is_original_lang:
+        temp = 'www/progress_bar_original.html'
+        bar = _progress_bar(total=seconds(subtitle.talk.video_duration),
+                            green=seconds(subtitle.time_quality_check_done),
+                            orange=seconds(subtitle.time_processed_syncing),
+                            red=seconds(subtitle.time_processed_transcribing))
+    else:
+        temp = 'www/progress_bar_translation.html'
+        bar = _progress_bar(total=seconds(subtitle.talk.video_duration),
+                            green=seconds(subtitle.time_processed_translating))
+        if small_translations:
+            bar['small'] = True
+
+    return mark_safe(render_to_string(temp, {'value': bar}))

--- a/www/views.py
+++ b/www/views.py
@@ -235,9 +235,9 @@ def seconds(sometime):
 def _progress_bar(total, green=0.0, orange=0.0, red=0.0, precision=1):
     scale = 100.0 / total
     green_amount = round(green * scale, precision)
-    orange_amount = min(round(orange * scale, precision), 100.0 - green_amount)
-    red_amount = min(round(red * scale, precision),
-                     100.0 - orange_amount - green_amount)
+    orange_amount = round(min(orange * scale, 100.0 - green_amount), precision)
+    red_amount = round(min(red * scale,
+                           100.0 - orange_amount - green_amount), precision)
     colored_amount = green_amount + orange_amount + red_amount
     grey_amount = round(100.0 - colored_amount, precision)
 

--- a/www/views.py
+++ b/www/views.py
@@ -235,8 +235,9 @@ def seconds(sometime):
 def _progress_bar(total, green=0.0, orange=0.0, red=0.0, precision=1):
     scale = 100.0 / total
     green_amount = round(green * scale, precision)
-    orange_amount = round(orange * scale, precision)
-    red_amount = round(red * scale, precision)
+    orange_amount = min(round(orange * scale, precision), 100.0 - green_amount)
+    red_amount = min(round(red * scale, precision),
+                     100.0 - orange_amount - green_amount)
     colored_amount = green_amount + orange_amount + red_amount
     grey_amount = round(100.0 - colored_amount, precision)
 


### PR DESCRIPTION
Centralize calculation of progress bars, and display (smaller) progress
bars for translations on the event page.

Resolves #11.