### PR TITLE
Fix special handling of Klingon

### DIFF
--- a/www/models.py
+++ b/www/models.py
@@ -206,6 +206,14 @@ class Subtitle(BasisModell):
     def translation_in_progress(self):
         return self._still_in_progress(self.time_processed_translating, state=11, original_language=False)
 
+    @property
+    def language_short(self):
+        lang = self.language.lang_amara_short
+
+        if lang == 'tlh':
+            lang = self.lang_short_srt
+        return lang
+
 
 # Links from the Fahrplan
 class Links(BasisModell):

--- a/www/templates/www/talk_small.html
+++ b/www/templates/www/talk_small.html
@@ -17,7 +17,7 @@
         <table style="width: 100%;">
             {% for subtitle in talk.subtitles %}
                 <tr>
-                    <th>{{ subtitle.language.lang_amara_short }}:</th>
+                    <th>{{ subtitle.language_short }}:</th>
                     <td>{{ subtitle|progress_bar:True }}</td>
                 </tr>
                 {% if not subtitle.complete and subtitle.revision > 0 %}


### PR DESCRIPTION
Klingon is used for mixed-language talks, so don't abbreviate it as
“tlh” but as “orig.”