### PR TITLE
Use deferred loading for embedded amara player

### DIFF
--- a/www/templates/www/talk.html
+++ b/www/templates/www/talk.html
@@ -214,7 +214,7 @@
    {% endfor %}
    </div>
 </div>
-<script type="text/javascript" src='https://amara.org/embedder-iframe'>
+<script type="text/javascript" src="https://amara.org/embedder-iframe" defer>
 </script>
 
 {% for sub in subtitles %}


### PR DESCRIPTION
Use deferred loading for the embedded amara player, so that loading times are not adversely affected by amara being slow.