### PR TITLE
warning message asking people for timestamp

### DIFF
--- a/www/templates/www/talk.html
+++ b/www/templates/www/talk.html
@@ -17,7 +17,7 @@
 
 <p class="alert alert-danger">
     <span class="glyphicon glyphicon-warning-sign" aria-hidden="true" style="margin-right: 5px;"></span>
-    If you suspend your transcription on amara.org, please add a timestamp below, how far your progress came! This will help others to resume your work!
+    If you suspend your transcription on amara.org, please add a timestamp below to indicate how far you progressed! This will help others to resume your work!
 </p>
 
 <p class="alert alert-danger">


### PR DESCRIPTION
I came to realise that many new transcriptions are started without any information, how far the person came doing the transcription. 

This is not bad, if only a few lines were added and you see someone just tried it out, but it takes quite some time to find the end of a quite a long transcription in a long video. Also we would of course like to have better statistics!