### PR TITLE
Strip both sides of input file lines

### DIFF
--- a/fix_sbv_linebreaks.py
+++ b/fix_sbv_linebreaks.py
@@ -20,7 +20,7 @@ def chunks(file):
     """Read `file`, splitting it at doubled linebreaks"""
     lines = []
     for line in file:
-        lines.append(re.sub(' {2,}', ' ', line.rstrip()))
+        lines.append(re.sub(' {2,}', ' ', line.strip()))
     return '\n'.join(lines).split('\n\n')
 
 


### PR DESCRIPTION
Youtube also discards whitespace at the beginning of lines, so don't try to keep that.

Signed-off-by: Maximilian Marx <mmarx@wh2.tu-dresden.de>