### PR TITLE
Cleaning up the settings configuration

### DIFF
--- a/subtitleStatus/settings.py
+++ b/subtitleStatus/settings.py
@@ -2,10 +2,10 @@
 Django settings for wwwsubs project.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.6/topics/settings/
+https://docs.djangoproject.com/en/1.11/topics/settings/
 
 For the full list of settings and their values, see
-https://docs.djangoproject.com/en/1.6/ref/settings/
+https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -17,10 +17,10 @@ TEMPLATE_DIRS = [PROJECT_ROOT+'/templates']
 
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = ')8^-u=gdtnye8jv6%d1r%$7sg!(wl4ki3++j3z%2b#@5-r=^c3'
+SECRET_KEY = '!!!GENERATE_FRESH_SECRET_KEY_PLEASE!!!'
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = False
@@ -63,20 +63,20 @@ WSGI_APPLICATION = 'subtitleStatus.wsgi.application'
 
 
 # Database
-# https://docs.djangoproject.com/en/1.6/ref/settings/#databases
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'subtitlestatus',
-        'USER': 'subtitlestatus',
-        'PASSWORD': 'zKpVBpWngEPz3Vb7wTp2AdqM3tCY6w2e',
+        'NAME': '!!!REPLACE_ME_WITH_ACTUAL_DBNAME!!!',
+        'USER': '!!!REPLACE_ME_WITH_ACTUAL_USERNAME!!!',
+        'PASSWORD': '!!!GENERATE_FRESH_PASSWORD!!!',
         'HOST': 'localhost'
     }
 }
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.6/topics/i18n/
+# https://docs.djangoproject.com/en/1.11/topics/i18n/
 
 LANGUAGE_CODE = 'en-us'
 
@@ -90,7 +90,7 @@ USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.6/howto/static-files/
+# https://docs.djangoproject.com/en/1.11/howto/static-files/
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static/")

--- a/www/templates/www/talk.html
+++ b/www/templates/www/talk.html
@@ -64,21 +64,13 @@
                                 <dt>Language</dt>
                                 <dd>{{talk.orig_language.display_name}}</dd>
                                 <dt>Abstract</dt>
-                                {% if talk.abstract != "None" %}
-                                   <dd>{{talk.abstract|linebreaksbr}}</dd>
-                                {% else %}
-                                   <dd> - </dd>
-                                {% endif %}
+				<dd>{{talk.abstract|safe|linebreaksbr|default_if_none:" - "}}</dd>
                             </dl>
                         </div> <!-- End Tab panel Video Data -->
                         
                         <!-- Tab panel Description -->
                         <div role="tabpanel" class="tab-pane" id="Description">
-                            {% if talk.description != "None" %}
-                                <p>{{talk.description|linebreaksbr}}</p>
-                            {% else %}
-                                <p>No description available.</p>
-                            {% endif%}
+                            <p>{{talk.description|safe|linebreaksbr|default_if_none:"No description available."}}</p>
                         </div> <!-- End Tab panel Description -->
                         
                         <!-- Tab panel Misc -->


### PR DESCRIPTION
Hello everyone,
this is a minor PR - for the sake of more user friendly config:
1. Replacing the example (I hope that they are not the actual production) credentials with placeholders.
2. Updating the documentation links, since the 1.6 references are gone.

PS: I hope that you are using different values for your production setup.
If not - please regenerate the exposed credentials (just to be safe).