### PR TITLE
keep existing line breaks

### DIFF
--- a/www/transforms.py
+++ b/www/transforms.py
@@ -51,7 +51,7 @@ def pad_from_trint(text):
                 continue
             out += ' ' + line
 
-    return out.replace('\n\n', '\n')
+    return out
 
 
 def pad_from_youtube(text):
@@ -69,7 +69,7 @@ def pad_from_youtube(text):
             else:
                  out += ' ' + line
 
-    return out.replace('\n\n', '\n')
+    return out
 
 
 def timing_from_pad(text):


### PR DESCRIPTION
Aus meiner eigenen Erfahrung sollte man die Zeilenumbrüche drin lassen, da sieh einem beim Korrigieren des Texts im Pad doch sehr helfen. Kann man später, wenn man die Untertitel dann aus dem Pad holt ja auch entfernen.

Vermutlich muss man Zeile 10 auch nochmal ran, kann man ja mal noch testen...

https://github.com/c3subtitles/subtitleStatus/blob/665bd8891b5ce51370ee3dc7a8a93405d6fbbca1/www/transforms.py#L5-L10

Wo die Timestamps aus dem Input SRT entfernt werden ist mir allerdings noch unklar.

Realer Vergleich: https://subtitles.pads.ccc.de/ep/pad/view/36c3-talk-10600/Zgr0DdbJYM zwischen Version 3505 und 3506 ab Minute 48

 